### PR TITLE
Cleanup JRE publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,13 @@ plugins {
     id "de.undercouch.download" version "3.4.3"
 }
 
-publishUrl = "http://artifactory.terasology.org/artifactory/libs-release-local"
 group = "org.terasology.jre"
 version = "1.0.0"
 
-jreVersion = "8u212"
+ext {
+    jreVersion = "8u212"
+    publishUrl = "http://artifactory.terasology.org/artifactory/libs-release-local"
+}
 
 enum JRE {
     Linux32("linux-i586","tar.gz"),
@@ -33,14 +35,26 @@ enum JRE {
     Windows32("windows-i586","zip"),
     Windows64("windows-amd64","zip");
 
-    URL downloadUrl
-    File targetArchive
+    String downloadArtifact
+    String archiveExtension
 
-    JRE(string filename, string extension) {
-        // Uses Bellsoft Liberica JRE
-        def baseUrl = "https://download.bell-sw.com/java/${jreVersion}"
-        this.downloadUrl = new URL("${baseUrl}/bellsoft-${jreVersion}-${filename}.${extension}")
-        this.targetArchive = new File("${projectDir}/jres/${this.class.name.toLowerCase()}.${extension}")
+    public URL getDownloadURL(String jreVersion) {
+        def baseUrl = "https://download.bell-sw.com/java/${jreVersion}/bellsoft-jre${jreVersion}"
+        def downloadUrl = new URL("${baseUrl}-${this.downloadArtifact}")
+        println downloadUrl
+
+        return downloadUrl
+    }
+
+    public File getTargetArchive(File projectDir) {
+        def targetArchive = new File("${projectDir}/jres/${this.name().toLowerCase()}.${this.archiveExtension}")
+
+        return targetArchive
+    }
+
+    JRE(String filename, String extension) {
+        this.downloadArtifact = "${filename}.${extension}"
+        this.archiveExtension = extension
     }
 }
 
@@ -55,19 +69,22 @@ JRE.each { arch ->
         group "Download"
         description "Downloads JRE for ${arch}"
 
-        src arch.downloadUrl
-        dest arch.targetArchive
+        // Uses Bellsoft Liberica JRE
+
+        src arch.getDownloadURL(jreVersion)
+        dest arch.getTargetArchive(projectDir)
         overwrite false
+        onlyIfModified true
     }
 
     downloadJreAll.dependsOn jreDownloadTask
     
     publishing.publications {
         "jre${arch}"(MavenPublication) {
-            artifact(arch.targetArchive) {
+            artifact(arch.getTargetArchive(projectDir)) {
                 builtBy jreDownloadTask
             }
-            artifactId "jre${jreVersion}-${arch.toLowerCase()}"
+            artifactId "jre${jreVersion}-${arch.name().toLowerCase()}"
             // TODO: customize POM
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -15,50 +15,60 @@
  */
 
 plugins {
-    id 'base'
-    id 'maven-publish'
-    id 'de.undercouch.download' version '3.4.3'
+    id "base"
+    id "maven-publish"
+    id "de.undercouch.download" version "3.4.3"
 }
 
-group = 'org.terasology.jre.liberica'
-version = '0.0.1'
+publishUrl = "http://artifactory.terasology.org/artifactory/libs-release-local"
+group = "org.terasology.jre"
+version = "1.0.0"
 
-// Uses Bellsoft Liberica JRE
-def jreUrlBase = 'https://download.bell-sw.com/java/8u212/bellsoft-jre8u212'
-def jreUrlFilenames = [
-        Linux64   : 'linux-amd64.tar.gz',
-        Linux32   : 'linux-i586.tar.gz',
-        Windows64 : 'windows-amd64.zip',
-        Windows32 : 'windows-i586.zip',
-        Mac       : 'macos-amd64.zip'
-]
+jreVersion = "8u212"
+
+enum JRE {
+    Linux32("linux-i586","tar.gz"),
+    Linux64("linux-amd64","tar.gz"),
+    MacOS("macos-amd64","zip"),
+    Windows32("windows-i586","zip"),
+    Windows64("windows-amd64","zip");
+
+    URL downloadUrl
+    File targetArchive
+
+    JRE(string filename, string extension) {
+        // Uses Bellsoft Liberica JRE
+        def baseUrl = "https://download.bell-sw.com/java/${jreVersion}"
+        this.downloadUrl = new URL("${baseUrl}/bellsoft-${jreVersion}-${filename}.${extension}")
+        this.targetArchive = new File("${projectDir}/jres/${this.class.name.toLowerCase()}.${extension}")
+    }
+}
 
 task downloadJreAll {
-    group 'Download'
-    description 'Downloads JRE for all platforms'
+    group "Download"
+    description "Downloads JRE for all platforms"
 }
 
-jreUrlFilenames.each { os, file ->
-    def jreTask = "downloadJre$os"
-    def jreZip  = "$projectDir/jre/${os.toLowerCase()}.zip"
-    
-    task "$jreTask"(type: Download) {
-        group 'Download'
-        description "Downloads JRE for $os"
+JRE.each { arch ->
 
-        src "$jreUrlBase-$file"
-        dest jreZip
+    def jreDownloadTask = task("downloadJre${arch}", type: Download) {
+        group "Download"
+        description "Downloads JRE for ${arch}"
+
+        src arch.downloadUrl
+        dest arch.targetArchive
         overwrite false
     }
-    
-    downloadJreAll.dependsOn tasks.named(jreTask).get()
+
+    downloadJreAll.dependsOn jreDownloadTask
     
     publishing.publications {
-        "jre$os"(MavenPublication) {
-            artifact(jreZip) {
-                builtBy tasks.named(jreTask).get()
+        "jre${arch}"(MavenPublication) {
+            artifact(arch.targetArchive) {
+                builtBy jreDownloadTask
             }
-            artifactId os.toLowerCase()
+            artifactId "jre${jreVersion}-${arch.toLowerCase()}"
+            // TODO: customize POM
         }
     }
 }
@@ -72,7 +82,7 @@ publishing {
                     password artifactoryPass
                 }
             }
-            url "http://artifactory.terasology.org/artifactory/libs-release-local"
+            url publishUrl
         }
     }
 }


### PR DESCRIPTION
- Adjust `groupId`, `artifactId` and `version`. We decided on the following pattern:
```
org.terasology.jre:jre<jreVersion>-<arch>:1.0.0
```
The version would seldomly change, maybe only in case we switch the vendor under the hood. We deliberately decided on being agnostic about the underlying JRE vendor as other libs and applications using the JRE provided by this repo should not care about this.
- Adjust task definition. Taks dependencies were a bit simplified by direct references.